### PR TITLE
Add MLflow Guide/Demo notebook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ COPY ["Pipfile", "Pipfile.lock", "./"]
 
 RUN pip install pipenv && pipenv install --ignore-pipfile
 
-COPY [".", "./"]
-
 ENV PYTHONPATH "${PYTHONPATH}:/home/kaggle"
 
 CMD ["pipenv", "run", "jupyter", "lab", "--allow-root", "--ip", "0.0.0.0"]

--- a/Pipfile
+++ b/Pipfile
@@ -4,15 +4,17 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+hyperopt = "==0.2.*"
 imbalanced-learn = "*"
 joblib = "==1.0.*"
 jupyterlab = "~=3.0.6"
-matplotlib = "==3.3.*"
+matplotlib = "~=3.3.4"
+mlflow = "==1.14.0"
 numpy = "==1.20.*"
 pandas = "==1.2.*"
 scikit-learn = "==0.24.*"
+seaborn = "~=0.11.1"
 xgboost = "*"
-hyperopt = "*"
 
 [dev-packages]
 

--- a/notebooks/MLflow-demo.ipynb
+++ b/notebooks/MLflow-demo.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "alpha-murray",
+   "metadata": {},
+   "source": [
+    "# MLflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "handmade-empire",
+   "metadata": {},
+   "source": [
+    "In a nutshell, MLflow is a way to maximise experiment organisation while minimising setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "changing-discipline",
+   "metadata": {},
+   "source": [
+    "## Installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "thick-deployment",
+   "metadata": {},
+   "source": [
+    "**In terminal:**\n",
+    "```bash\n",
+    "pipenv install mlflow\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "prerequisite-castle",
+   "metadata": {},
+   "source": [
+    "## Usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "infinite-exhibition",
+   "metadata": {},
+   "source": [
+    "MLflow's UI runs in a browser on a specific port the same way Jupyter does. Unless you are running Jupyter in a detached Docker container you will need to open a second terminal to run MLflow:\n",
+    "\n",
+    "**In terminal:**\n",
+    "```bash\n",
+    "pipenv run mlflow ui\n",
+    "```\n",
+    "\n",
+    "This will output a URI you need for launching the UI and attach your experiment to. MLflow refers to it as the Tracking URI and will look like one of these:\n",
+    "\n",
+    "```\n",
+    "http://kubernetes.docker.internal:5000\n",
+    "```\n",
+    "```\n",
+    "http://localhost:5000\n",
+    "```\n",
+    "```\n",
+    "127.0.0.1:5000\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "radio-thesaurus",
+   "metadata": {},
+   "source": [
+    "**In notebook:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "diverse-civilization",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mlflow\n",
+    "\n",
+    "mlflow.set_tracking_uri('http://localhost:5000')\n",
+    "mlflow.set_experiment(experiment_name='Name of this experiment')\n",
+    "\n",
+    "with mlflow.start_run(run_name='Name of this experiment run'):\n",
+    "    mlflow.log_param('Any Param 1', 'Any value')\n",
+    "    mlflow.log_param('Any Param 2', 1_234)\n",
+    "    mlflow.log_param('Any Param 3', False)\n",
+    "    mlflow.log_metric('Any Float Metric', 1.23)\n",
+    "    mlflow.log_metric('Any Float 2', 9.555)\n",
+    "    mlflow.log_metric('Any Float 2', 5.555)\n",
+    "    mlflow.log_metric('Any Float 2', 7.555)\n",
+    "    mlflow.log_metric('Any Float 2', 3.555) # All metrics will be logged, but this will be the final value\n",
+    "    mlflow.end_run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sophisticated-enough",
+   "metadata": {},
+   "source": [
+    "## Mlflow UI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "removed-accused",
+   "metadata": {},
+   "source": [
+    "If you refresh the MLFlow Tracking URI (e.g. localhost:5000), you will see this experiment appear in the left sidebar:\n",
+    "\n",
+    "![MLflow sidebar experiment](https://i.snipboard.io/WzZqKp.jpg)\n",
+    "\n",
+    "The experiment run will appear in the table of runs, showing the details it ran with:\n",
+    "\n",
+    "![MLflow table of runs](https://i.snipboard.io/gsJICz.jpg)\n",
+    "\n",
+    "Clicking into the run will show more details, including the run time, tags and artifacts:\n",
+    "\n",
+    "![MLflow run details page](https://i.snipboard.io/ktwib9.jpg)\n",
+    "\n",
+    "The page will also link to charts of the metrics that were logged:\n",
+    "\n",
+    "![MLflow metrics chart](https://i.snipboard.io/9leib2.jpg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sensitive-colorado",
+   "metadata": {},
+   "source": [
+    "## Basic notebook example usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "valued-proof",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from mlflow import set_tracking_uri, set_experiment, start_run, end_run, log_metric, log_param, log_artifacts\n",
+    "\n",
+    "set_tracking_uri('http://localhost:5000')\n",
+    "set_experiment(experiment_name='kaggle-nba')\n",
+    "\n",
+    "with start_run(run_name='Logistic Regression penalty and C test'):\n",
+    "    df = pd.read_csv('../data/raw/train.csv')\n",
+    "    target = df.pop('TARGET_5Yrs')\n",
+    "    df = df.loc[:, 'GP':'TOV']\n",
+    "\n",
+    "    penalty = 'l2'\n",
+    "    C = 1.4\n",
+    "\n",
+    "    log_param('penalty', penalty)\n",
+    "    log_param('C', C)\n",
+    "\n",
+    "    clf = LogisticRegression(penalty=penalty, C=C, max_iter=10_000)\n",
+    "    clf.fit(df, target)\n",
+    "    accuracy = clf.score(df, target)\n",
+    "\n",
+    "    log_metric('accuracy', accuracy)\n",
+    "\n",
+    "    end_run()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
- Tidy up Dockerfile
- Add seaborn for my use, tidy dependency versions, add mlflow
- Add notebook showing how to use MLflow

Main thing is the notebook with MLflow demo. All you have to do is run `pipenv install mlflow` then `pipenv run mlflow ui`, and you'll be able to run the notebook as is to understand how MLflow works, then adapt it to your own notebook.